### PR TITLE
Small modification to how Errors are being created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ begin
   })
   puts "YAY!" if response[:ok] == true # All JSON responses are converted to hash's
 rescue Dirigible::Error => e
-  puts "BUSTED!!!"
+  puts "BUSTED!!! #{e.message}"
 end
 ```
 

--- a/lib/dirigible/error.rb
+++ b/lib/dirigible/error.rb
@@ -1,6 +1,6 @@
 module Dirigible
   # Custom error class for rescuing from all known Urban Airship errors
-  class Error < StandardError; attr_accessor :error end
+  class Error < StandardError; end
 
   # Raised when Urban Airship returns HTTP status code 400
   class BadRequest < Error; end

--- a/lib/dirigible/utils.rb
+++ b/lib/dirigible/utils.rb
@@ -2,16 +2,18 @@ module Dirigible
   # @private
   module Utils
     def self.handle_api_error(response)
-      error = case response.status
-      when 400 then BadRequest.new
-      when 401 then Unauthorized.new
-      when 404 then NotFound.new
-      when 405 then MethodNotAllowed.new
-      when 406 then NotAcceptable.new
-      else Error.new
+      message = parse_json(response.body)
+
+      klass = case response.status
+        when 400 then BadRequest
+        when 401 then Unauthorized
+        when 404 then NotFound
+        when 405 then MethodNotAllowed
+        when 406 then NotAcceptable
+        else Error
       end
-      error.error = parse_json(response.body)
-      raise error
+
+      raise klass.new(message)
     end
 
     def self.parse_json(json)


### PR DESCRIPTION
Errors now use the standard message attribute rather than a custom error attribute. 
Readme now reflects that a user can access the error in error.message.
