### PR TITLE
fix documentation typo

### DIFF
--- a/lib/dirigible/push.rb
+++ b/lib/dirigible/push.rb
@@ -9,7 +9,7 @@ class Dirigible::Push
   # @example Example request:
   #   Dirigible::Push.create({
   #     audience: { device_token: "998BAD77A8347EFE7920F5367A4811C4385D526AE42C598A629A73B94EEDBAC8" },
-  #     notification: { alert: "Hello"! },
+  #     notification: { alert: "Hello!" },
   #     device_types: "all"
   #   })
   #


### PR DESCRIPTION
Fixes a documentation typo in Dirigible::Push.create. 
