### PR TITLE
Fix response for Dirigible::DeviceRegistration.delete_device_token

### DIFF
--- a/lib/dirigible/request.rb
+++ b/lib/dirigible/request.rb
@@ -38,7 +38,7 @@ module Dirigible
 
       Utils.handle_api_error(response) unless (200..399).include?(response.status)
 
-      Utils.parse_json(response.body) unless response.body == ''
+      Utils.parse_json(response.body) unless response.body.blank?
     end
   end
 end


### PR DESCRIPTION
Dirigible::DeviceRegistration.delete_device_token(token) returns a 204 response and a nil body. Change body == ‘’ to body.blank? to handle two different types of empty response bodies.
