### PR TITLE
DeviceRegistration.register_apid takes optional hash

### DIFF
--- a/lib/dirigible/device_registration.rb
+++ b/lib/dirigible/device_registration.rb
@@ -44,8 +44,8 @@ class Dirigible::DeviceRegistration
   #   })
   #
   # @see http://docs.urbanairship.com/reference/api/v3/registration.html#apid-registration
-  def self.register_apid(id, params)
-    Dirigible.put("/apids/#{id}", params)
+  def self.register_apid(id, options = {})
+    Dirigible.put("/apids/#{id}", options)
   end
 
   # Register this PIN with this application. This will mark


### PR DESCRIPTION
Make params (now named options) optional for Dirigible::DeviceRegistration.register_apid as it is for the other device registration calls
