### PR TITLE
Parse and provide next page params for device listing, add device count API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ end
 * [Get Backberry PIN device information](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.get_device_pin)
 * [Get iOS device token information](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.get_device_token)
 * [List Android APID's registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_apids)
-* [List Blackberry PIN's registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_pin)
-* [List iOS device tokens registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_token)
-* [List device tokens that can't recieve messages](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.device_token_feedback)
+* [List Blackberry PIN's registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_pins)
+* [Count iOS device tokens registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.count_device_tokens)
+* [List iOS device tokens registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_tokens)
+* [List iOS device tokens that can't recieve messages](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.device_token_feedback)
 
 ### Device Registration
 

--- a/dirigible.gemspec
+++ b/dirigible.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware", "~> 0.9"
   spec.add_dependency "hashie",             "~> 2.0"
   spec.add_dependency "multi_json",         "~> 1.8"
+  spec.add_dependency "rack"
 end

--- a/lib/dirigible/device_information.rb
+++ b/lib/dirigible/device_information.rb
@@ -31,15 +31,29 @@ class Dirigible::DeviceInformation
     Dirigible.get("/device_pins/#{id}")
   end
 
+  # Count iOS device tokens registered to this application
+  #
+  # @example Example request:
+  #   Dirigible::DeviceInformation.count_device_tokens[:device_tokens_count]
+  #   Dirigible::DeviceInformation.count_device_tokens[:active_device_tokens_count]
+  #
+  # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
+  def self.count_device_tokens
+    Dirigible.get("/device_tokens/count")
+  end
+
+
   # Fetch iOS device tokens registered to this application
   # and associated metadata.
   #
   # @example Example request:
   #   Dirigible::DeviceInformation.list_device_tokens
+  #   response = Dirigible::DeviceInformation.list_device_tokens(:limit => 5)
+  #   response = Dirigible::DeviceInformation.list_device_tokens(response) if response.has_key?(:next_page)
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
-  def self.list_device_tokens
-    Dirigible.get('/device_tokens')
+  def self.list_device_tokens(options = {})
+    list_devices('/device_tokens', options)
   end
 
   # Fetch Android APIDs registered to this application and
@@ -47,10 +61,12 @@ class Dirigible::DeviceInformation
   #
   # @example Example request:
   #   Dirigible::DeviceInformation.list_apids
+  #   response = Dirigible::DeviceInformation.list_apids(:limit => 5)
+  #   response = Dirigible::DeviceInformation.list_apids(response) if response.has_key?(:next_page)
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
-  def self.list_apids
-    Dirigible.get('/apids')
+  def self.list_apids(options = {})
+    list_devices('/apids', options)
   end
 
   # Fetch BlackBerry PINs registered to this application and
@@ -58,20 +74,39 @@ class Dirigible::DeviceInformation
   #
   # @example Example request:
   #   Dirigible::DeviceInformation.list_device_pins
+  #   response = Dirigible::DeviceInformation.list_device_pins(:limit => 5)
+  #   response = Dirigible::DeviceInformation.list_device_pins(response) if response.has_key?(:next_page)
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
-  def self.list_device_pins
-    Dirigible.get('/device_pins')
+  def self.list_device_pins(options = {})
+    list_devices('/device_pins', options)
   end
 
   # Fetch device tokens that can't recieve messages because
   # the app has been uninstalled.
   #
   # @example Example request:
-  #   Dirigible::DeviceInformation.device_token_feedback('2009-06-15')
+  #   Dirigible::DeviceInformation.device_token_feedback(Date.yesterday)
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#feedback
   def self.device_token_feedback(since)
     Dirigible.get("/device_tokens/feedback", { since: since })
   end
+
+  private
+  def self.list_devices(path, options = {})
+    merge_start_limit(Dirigible.get(path, options.slice(:start, :limit)))
+  end
+
+  def self.merge_start_limit(response)
+    return response unless response.is_a?(Hash) && response.has_key?(:next_page)
+
+    next_page = response[:next_page] || ''
+    query_string_params = next_page.split('?').last
+
+    params_hash = Rack::Utils.parse_nested_query(query_string_params).symbolize_keys!
+
+    response.merge(params_hash.slice(:start, :limit))
+  end
+
 end


### PR DESCRIPTION
All the device listing API calls take an optional start and limit parameter and will return a next_page field in the response if there is more than one page of data.  I added options ={} to all the device listing methods and parse the next_page out of the response (if present) and inject the start/limit parameters into the root of the response hash.  I also found that the device token count method was missing and added that.
- parse the device_listing responses and inject the start/limit from the next_page URL into the response hash
- Add a missing API Method: /api/device_tokens/count/
- Readme update
