### PR TITLE
Add Device Token Count / Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ end
 * [Get Backberry PIN device information](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.get_device_pin)
 * [Get iOS device token information](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.get_device_token)
 * [List Android APID's registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_apids)
-* [List Blackberry PIN's registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_pin)
-* [List iOS device tokens registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_token)
-* [List device tokens that can't recieve messages](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.device_token_feedback)
+* [List Blackberry PIN's registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_pins)
+* [Count iOS device tokens registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.count_device_tokens)
+* [List iOS device tokens registered to an application](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.list_device_tokens)
+* [List iOS device tokens that can't recieve messages](http://rdoc.info/github/anthonator/dirigible/master/Dirigible/DeviceInformation.device_token_feedback)
 
 ### Device Registration
 

--- a/lib/dirigible/device_information.rb
+++ b/lib/dirigible/device_information.rb
@@ -31,6 +31,18 @@ class Dirigible::DeviceInformation
     Dirigible.get("/device_pins/#{id}")
   end
 
+  # Count iOS device tokens registered to this application
+  #
+  # @example Example request:
+  #   Dirigible::DeviceInformation.count_device_tokens[:device_tokens_count]
+  #   Dirigible::DeviceInformation.count_device_tokens[:active_device_tokens_count]
+  #
+  # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
+  def self.count_device_tokens
+    Dirigible.get("/device_tokens/count")
+  end
+
+
   # Fetch iOS device tokens registered to this application
   # and associated metadata.
   #


### PR DESCRIPTION
- Add a missing API Method: /api/device_tokens/count/

Readme:
- Add devices_count to the read me
- Fix links to listing pins and device tokens
- Add iOS before one instance of device tokens.
