### PR TITLE
Handle Service Unavailable API Error.

### DIFF
--- a/lib/dirigible/error.rb
+++ b/lib/dirigible/error.rb
@@ -16,4 +16,7 @@ module Dirigible
 
   # Raised when Urban Airship returns HTTP status code 406
   class NotAcceptable < Error; end
+
+  # Raised when Urban Airship returns HTTP status code 503
+  class ServiceUnavailable < Error; end
 end

--- a/lib/dirigible/utils.rb
+++ b/lib/dirigible/utils.rb
@@ -10,6 +10,7 @@ module Dirigible
         when 404 then NotFound
         when 405 then MethodNotAllowed
         when 406 then NotAcceptable
+        when 503 then ServiceUnavailable
         else Error
       end
 


### PR DESCRIPTION
We sometimes get this error:

```
Dirigible::Error: <HTML><HEAD> <TITLE>Service Unavailable</TITLE> </HEAD><BODY> <H1>Service Unavailable - Zero size object</H...ervice your request. Please try again later.<P> Reference&#32;&#35;15&#46;f6bc6775&#46;1410792978&#46;fa00cd </BODY></HTML>
```

```
/gems/dirigible-1.1.1/lib/dirigible/utils.rb:16 in "handle_api_error"
/gems/dirigible-1.1.1/lib/dirigible/request.rb:39 in "request"
/gems/dirigible-1.1.1/lib/dirigible/request.rb:8 in "post"
...
```

So we thought it's better to handle 503 response with a more specific error. Much better than parsing the error message.
