### PR TITLE
Try to parse error JSON. Fix URL slashes.

### DIFF
--- a/lib/dirigible/device_information.rb
+++ b/lib/dirigible/device_information.rb
@@ -39,7 +39,7 @@ class Dirigible::DeviceInformation
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
   def self.count_device_tokens
-    Dirigible.get("/device_tokens/count")
+    Dirigible.get("/device_tokens/count/")
   end
 
 
@@ -55,7 +55,7 @@ class Dirigible::DeviceInformation
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
   def self.list_device_tokens(options = {})
-    List.new(Dirigible.get('/device_tokens', options))
+    List.new(Dirigible.get('/device_tokens/', options))
   end
 
   # Fetch Android APIDs registered to this application and
@@ -70,7 +70,7 @@ class Dirigible::DeviceInformation
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
   def self.list_apids(options = {})
-    List.new(Dirigible.get('/apids', options))
+    List.new(Dirigible.get('/apids/', options))
   end
 
   # Fetch BlackBerry PINs registered to this application and
@@ -85,7 +85,7 @@ class Dirigible::DeviceInformation
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#device-listing
   def self.list_device_pins(options = {})
-    List.new(Dirigible.get('/device_pins', options))
+    List.new(Dirigible.get('/device_pins/', options))
   end
 
   # Fetch device tokens that can't recieve messages because
@@ -96,7 +96,7 @@ class Dirigible::DeviceInformation
   #
   # @see http://docs.urbanairship.com/reference/api/v3/device_information.html#feedback
   def self.device_token_feedback(since)
-    Dirigible.get("/device_tokens/feedback", { since: since })
+    Dirigible.get("/device_tokens/feedback/", { since: since })
   end
   
   class List

--- a/lib/dirigible/error.rb
+++ b/lib/dirigible/error.rb
@@ -1,6 +1,9 @@
 module Dirigible
   # Custom error class for rescuing from all known Urban Airship errors
-  class Error < StandardError; alias_method :error, :message end
+  class Error < StandardError
+    alias_method :error, :message
+    attr_accessor :parsed
+  end
 
   # Raised when Urban Airship returns HTTP status code 400
   class BadRequest < Error; end

--- a/lib/dirigible/feed.rb
+++ b/lib/dirigible/feed.rb
@@ -17,7 +17,7 @@ class Dirigible::Feed
   #
   # @see http://docs.urbanairship.com/reference/api/v3/feeds.html#creating-a-new-feed
   def self.create(params)
-    Dirigible.post('/feeds', params)
+    Dirigible.post('/feeds/', params)
   end
 
   # Returns information about that particular feed.

--- a/lib/dirigible/location.rb
+++ b/lib/dirigible/location.rb
@@ -10,7 +10,7 @@ class Dirigible::Location
   #
   # @see http://docs.urbanairship.com/reference/api/v3/location.html#location-boundary-information
   def self.search_by_name(query, boundary_type = nil)
-    Dirigible.get('/location', { q: query, type: boundary_type })
+    Dirigible.get('/location/', { q: query, type: boundary_type })
   end
 
   # Search for a location by latitude and longitude.
@@ -60,6 +60,6 @@ class Dirigible::Location
   #
   # @see http://docs.urbanairship.com/reference/api/v3/location.html#location-data-ranges
   def self.cutoff_dates
-    Dirigible.get("/segments/dates")
+    Dirigible.get("/segments/dates/")
   end
 end

--- a/lib/dirigible/push.rb
+++ b/lib/dirigible/push.rb
@@ -15,7 +15,7 @@ class Dirigible::Push
   #
   # @see http://docs.urbanairship.com/reference/api/v3/push.html#push
   def self.create(params)
-    Dirigible.post('/push', params)
+    Dirigible.post('/push/', params)
   end
 
   # Accept the same range of payloads as /api/push, but parse

--- a/lib/dirigible/request.rb
+++ b/lib/dirigible/request.rb
@@ -21,11 +21,11 @@ module Dirigible
     def request(method, path, options, headers)
       headers.merge!({
         'User-Agent' => user_agent,
-        'Accept' => 'application/vnd.urbanairship+json; version=3;',
+        'Accept' => 'application/vnd.urbanairship+json; version=3;'
       })
 
       response = connection.send(method) do |request|
-        request.url("#{endpoint}#{path}/")
+        request.url("#{endpoint}#{path}")
 
         if [:post, :put].member?(method)
           request.body = options.to_json

--- a/lib/dirigible/schedule.rb
+++ b/lib/dirigible/schedule.rb
@@ -19,7 +19,7 @@ class Dirigible::Schedule
   #
   # @see http://docs.urbanairship.com/reference/api/v3/schedule.html#schedule-a-notification
   def self.create(params)
-    Dirigible.post('/schedules', params)
+    Dirigible.post('/schedules/', params)
   end
 
   # List all existing schedules. Returns an array of schedule
@@ -30,7 +30,7 @@ class Dirigible::Schedule
   #
   # @see http://docs.urbanairship.com/reference/api/v3/schedule.html#list-schedules
   def self.list
-    Dirigible.get('/schedules')
+    Dirigible.get('/schedules/')
   end
 
   # Fetch the current definition of a single schedule

--- a/lib/dirigible/segment.rb
+++ b/lib/dirigible/segment.rb
@@ -7,7 +7,7 @@ class Dirigible::Segment
   #
   # @see http://docs.urbanairship.com/reference/api/v3/segments.html#segments-information
   def self.list
-    Dirigible.get('/segments')
+    Dirigible.get('/segments/')
   end
 
   # Fetch information about a particular segment.
@@ -35,7 +35,7 @@ class Dirigible::Segment
   #
   # @see http://docs.urbanairship.com/reference/api/v3/segments.html#segment-creation
   def self.create(params)
-    Dirigible.post('/segments', params)
+    Dirigible.post('/segments/', params)
   end
 
   # Change the definition of the segment.

--- a/lib/dirigible/tag.rb
+++ b/lib/dirigible/tag.rb
@@ -7,7 +7,7 @@ class Dirigible::Tag
   #
   # @see http://docs.urbanairship.com/reference/api/v3/tags.html#tag-listing
   def self.list
-    Dirigible.get('/tags')
+    Dirigible.get('/tags/')
   end
 
   # Explicitly create a tag with no devices associated with
@@ -107,6 +107,6 @@ class Dirigible::Tag
   #
   # @see http://docs.urbanairship.com/reference/api/v3/tags.html#batch-modification-of-tags
   def self.batch(params)
-    Dirigible.post("/tags/batch", params)
+    Dirigible.post("/tags/batch/", params)
   end
 end

--- a/lib/dirigible/utils.rb
+++ b/lib/dirigible/utils.rb
@@ -2,7 +2,7 @@ module Dirigible
   # @private
   module Utils
     def self.handle_api_error(response)
-      message = parse_message(response)
+
 
       klass = case response.status
         when 400 then BadRequest
@@ -14,14 +14,18 @@ module Dirigible
         else Error
       end
 
-      raise klass.new(message)
+      err = klass.new(response.body)
+      err.parsed = parse_message(response)
+      raise err
+
     end
 
     def self.parse_json(json)
       MultiJson.load(json, symbolize_keys: true)
     end
-    
+
     def self.parse_message(response)
+
       begin
         parse_json(response.body)
       rescue


### PR DESCRIPTION
This corrects the trailing slash use on the URLs we previously discussed.
It also sets parsed error info on error objects.
